### PR TITLE
Performance and OO-ness

### DIFF
--- a/RaspberryPiDotNet/DS1620.cs
+++ b/RaspberryPiDotNet/DS1620.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 
 // Derived based on work done by AdamS at http://forums.netduino.com/index.php?/topic/3335-netduino-plus-and-ds1620-anyone/page__view__findpost__p__22972

--- a/RaspberryPiDotNet/GPIODebug.cs
+++ b/RaspberryPiDotNet/GPIODebug.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace RaspberryPiDotNet
 {
     /// <summary>
     /// Raspberry Pi GPIO debug class.
     /// </summary>
-    public class GPIODebug : GPIO, IDisposable
+    public class GPIODebug : GPIO
     {
         private bool _currentValue = false;
 
@@ -18,7 +15,7 @@ namespace RaspberryPiDotNet
         /// </summary>
         /// <param name="pin">The GPIO pin</param>
         public GPIODebug(GPIOPins pin)
-            : base(pin,DirectionEnum.OUT,false)
+            : this(pin,GPIODirection.Out,false)
         {
         }
 
@@ -27,8 +24,8 @@ namespace RaspberryPiDotNet
         /// </summary>
         /// <param name="pin">The GPIO pin</param>
         /// <param name="direction">Direction</param>
-        public GPIODebug(GPIOPins pin, DirectionEnum direction)
-            : base(pin, direction, false)
+        public GPIODebug(GPIOPins pin, GPIODirection direction)
+            : this(pin, direction, false)
         {
         }
 
@@ -38,51 +35,8 @@ namespace RaspberryPiDotNet
         /// <param name="pin">The GPIO pin</param>
         /// <param name="direction">Direction</param>
         /// <param name="initialValue">Initial Value</param>
-        public GPIODebug(GPIOPins pin, DirectionEnum direction, bool initialValue)
+        public GPIODebug(GPIOPins pin, GPIODirection direction, bool initialValue)
             : base(pin, direction, initialValue)
-        {
-            Write(pin, initialValue);
-        }
-        #endregion
-
-        #region Static Methods
-        /// <summary>
-        /// Export the GPIO setting the direction. This creates the /sys/class/gpio/gpioXX directory.
-        /// </summary>
-        /// <param name="pin">The GPIO pin</param>
-        /// <param name="direction"></param>
-        private static void ExportPin(GPIOPins pin, DirectionEnum direction)
-        {
-        }
-
-        /// <summary>
-        /// Unexport the GPIO. This removes the /sys/class/gpio/gpioXX directory.
-        /// </summary>
-        /// <param name="pin">The pin to unexport</param>
-        private static void UnexportPin(GPIOPins pin)
-        {
-        }
-
-        /// <summary>
-        /// Static method to write a value to the specified pin. Does nothing when using the GPIODebug class.
-        /// </summary>
-        /// <param name="pin">The GPIO pin</param>
-        /// <param name="value">The value to write to the pin</param>
-        public static void Write(GPIOPins pin, bool value)
-        {
-        }
-
-        /// <summary>
-        /// Static method to read a value to the specified pin. Always returns false when using the GPIODebug class.
-        /// </summary>
-        /// <param name="pin">The GPIO pin</param>
-        /// <returns>The value read from the pin</returns>
-        public static bool Read(GPIOPins pin)
-        {
-            return false;
-        }
-
-        public static void CleanUp()
         {
         }
         #endregion
@@ -94,7 +48,9 @@ namespace RaspberryPiDotNet
         /// <param name="value">The value to write to the pin</param>
         public override void Write(bool value)
         {
-            _currentValue = value;
+			System.Diagnostics.Debug.WriteLine("GPIO pin " + _pin + " set to " + value);
+			base.Write(value);
+			_currentValue = value;
         }
 
         /// <summary>
@@ -103,6 +59,8 @@ namespace RaspberryPiDotNet
         /// <returns>The value read from the pin</returns>
         public override bool Read()
         {
+			System.Diagnostics.Debug.WriteLine("GPIO pin " + _pin + " reads as " + _currentValue);
+			base.Read();
             return _currentValue;
         }
 
@@ -111,7 +69,7 @@ namespace RaspberryPiDotNet
         /// </summary>
         public override void Dispose()
         {
-            UnexportPin(_pin);
+			base.Dispose();
         }
         #endregion
     }

--- a/RaspberryPiDotNet/GPIODirection.cs
+++ b/RaspberryPiDotNet/GPIODirection.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RaspberryPiDotNet
+{
+    /// <summary>
+    /// Specifies the direction of the GPIO port
+    /// </summary>
+    public enum GPIODirection { In, Out };
+}

--- a/RaspberryPiDotNet/GPIOFile.cs
+++ b/RaspberryPiDotNet/GPIOFile.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Diagnostics;
 using System.IO;
 
@@ -12,7 +9,7 @@ namespace RaspberryPiDotNet
     /// <summary>
     /// Raspberry Pi GPIO using the file-based access method.
     /// </summary>
-    public class GPIOFile : GPIO, IDisposable
+    public class GPIOFile : GPIO
     {
         /// <summary>
         /// The path on the Raspberry Pi for the GPIO interface
@@ -25,7 +22,7 @@ namespace RaspberryPiDotNet
         /// </summary>
         /// <param name="pin">The GPIO pin</param>
         public GPIOFile(GPIOPins pin)
-            : base(pin,DirectionEnum.OUT,false)
+            : this(pin,GPIODirection.Out,false)
         {
         }
 
@@ -34,10 +31,9 @@ namespace RaspberryPiDotNet
         /// </summary>
         /// <param name="pin">The GPIO pin</param>
         /// <param name="direction">Direction</param>
-        public GPIOFile(GPIOPins pin, DirectionEnum direction)
-            : base(pin, direction, false)
+        public GPIOFile(GPIOPins pin, GPIODirection direction)
+            : this(pin, direction, false)
         {
-            ExportPin(pin, direction);
         }
 
         /// <summary>
@@ -46,120 +42,38 @@ namespace RaspberryPiDotNet
         /// <param name="pin">The GPIO pin</param>
         /// <param name="direction">Direction</param>
         /// <param name="initialValue">Initial Value</param>
-        public GPIOFile(GPIOPins pin, DirectionEnum direction, bool initialValue)
+        public GPIOFile(GPIOPins pin, GPIODirection direction, bool initialValue)
             : base(pin, direction, initialValue)
         {
-            ExportPin(pin, direction);
-            Write(pin, initialValue);
         }
 
-        ~GPIOFile()
-        {
-            UnexportPin(_pin);
-        }
         #endregion
 
-        #region Static Methods
-        /// <summary>
-        /// Export the GPIO setting the direction. This creates the /sys/class/gpio/gpioXX directory.
-        /// </summary>
-        /// <param name="pin">The GPIO pin</param>
-        /// <param name="direction"></param>
-        private static void ExportPin(GPIOPins pin, DirectionEnum direction)
-        {
-            // If the pin is already exported, check it's in the proper direction
-            if (_exportedPins.Keys.Contains((int)pin))
-                // If the direction matches, return out of the function. If not, change the direction
-                if (_exportedPins[(int)pin] == direction)
-                    return;
-                else
-                {
-                    // Set the direction on the pin and update the exported list
-                    File.WriteAllText(GPIO_PATH + "gpio" + GetGPIONumber(pin) + "/direction", direction.ToString().ToLower());
-                    _exportedPins[(int)pin] = direction;
-                    return;
-                }
+		#region Properties
 
-            if (!Directory.Exists(GPIO_PATH + "gpio" + GetGPIONumber(pin)))
-            {
-                Debug.WriteLine("Exporting " + GetGPIONumber(pin));
-                //export
-                File.WriteAllText(GPIO_PATH + "export", GetGPIONumber(pin));
-            }
+		/// <summary>
+		/// Gets or sets the communication direction for this pin
+		/// </summary>
+		public override GPIODirection PinDirection
+		{
+			get
+			{
+				return base.PinDirection;
+			}
+			set
+			{
+				if (PinDirection != (base.PinDirection = value)) // Left to right eval ensures base class gets to check for disposed object access
+				{
+					if (!Directory.Exists(GPIO_PATH + "gpio" + (uint)_pin))
+						File.WriteAllText(GPIO_PATH + "export", ((uint)_pin).ToString());
 
-            // set i/o direction
-            Debug.WriteLine("Setting direction on pin " + pin + "/gpio " + (int)pin + " as " + direction);
-            File.WriteAllText(GPIO_PATH + "gpio" + GetGPIONumber(pin) + "/direction", direction.ToString().ToLower());
+					// set i/o direction
+					File.WriteAllText(GPIO_PATH + "gpio" + (uint)_pin + "/direction", value.ToString().ToLower());
+				}
+			}
+		}
 
-            // Update the list of exported pins
-            _exportedPins[(int)pin] = direction;
-        }
-
-        /// <summary>
-        /// Unexport the GPIO. This removes the /sys/class/gpio/gpioXX directory.
-        /// </summary>
-        /// <param name="pin">The pin to unexport</param>
-        private static void UnexportPin(GPIOPins pin)
-        {
-            Debug.WriteLine("unexporting pin " + pin);
-            File.WriteAllText(GPIO_PATH + "unexport", GetGPIONumber(pin));
-
-            // Remove the pin from the list of exported pins
-            _exportedPins.Remove((int)pin);
-        }
-
-        /// <summary>
-        /// Static method to write a value to the specified pin. When using the static methods ensure you use the CleanUp() method when done.
-        /// </summary>
-        /// <param name="pin">The GPIO pin</param>
-        /// <param name="value">The value to write to the pin</param>
-        public static void Write(GPIOPins pin, bool value)
-        {
-            if (pin == GPIOPins.GPIO_NONE)
-                return;
-
-            ExportPin(pin, DirectionEnum.OUT);
-
-            string writeValue = value ? "1" : "0";
-            File.WriteAllText(GPIO_PATH + "gpio" + GetGPIONumber(pin) + "/value", writeValue);
-            Debug.WriteLine("output to pin " + pin + "/gpio " + (int)pin + ", value was " + value);
-        }
-
-        /// <summary>
-        /// Static method to read a value to the specified pin. When using the static methods ensure you use the CleanUp() method when done.
-        /// </summary>
-        /// <param name="pin">The GPIO pin</param>
-        /// <returns>The value read from the pin</returns>
-        public static bool Read(GPIOPins pin)
-        {
-            bool returnValue = false;
-
-            ExportPin(pin, DirectionEnum.IN);
-
-            string filename = GPIO_PATH + "gpio" + GetGPIONumber(pin) + "/value";
-            if (File.Exists(filename))
-            {
-                string readValue = File.ReadAllText(filename);
-                if (readValue.Length > 0 && readValue[0] == '1')
-                    returnValue = true;
-            }
-            else
-                throw new Exception(string.Format("Cannot read from {0}. File does not exist", pin));
-
-            Debug.WriteLine("input from pin " + pin + "/gpio " + (int)pin + ", value was " + returnValue);
-
-            return returnValue;
-        }
-
-        public static void CleanUp()
-        {
-            // Loop over all exported pins and unexported them
-            foreach (GPIOPins pin in _exportedPins.Keys)
-            {
-                UnexportPin(pin);
-            }
-        }
-        #endregion
+		#endregion
 
         #region Class Methods
         /// <summary>
@@ -168,8 +82,8 @@ namespace RaspberryPiDotNet
         /// <param name="value">The value to write to the pin</param>
         public override void Write(bool value)
         {
-            // Call the static method
-            Write(_pin, value);
+			base.Write(value);
+			File.WriteAllText(GPIO_PATH + "gpio" + (uint)_pin + "/value", value ? "1" : "0");
         }
 
         /// <summary>
@@ -178,8 +92,9 @@ namespace RaspberryPiDotNet
         /// <returns>The value read from the pin</returns>
         public override bool Read()
         {
-            // Call the static method
-            return Read(_pin);
+			base.Read();
+			string readValue = File.ReadAllText(GPIO_PATH + "gpio" + (uint)_pin + "/value");
+			return (readValue.Length > 0 && readValue[0] == '1');
         }
 
         /// <summary>
@@ -187,7 +102,8 @@ namespace RaspberryPiDotNet
         /// </summary>
         public override void Dispose()
         {
-            UnexportPin(_pin);
+            base.Dispose();
+			File.WriteAllText(GPIO_PATH + "unexport", ((uint)_pin).ToString());
         }
         #endregion
     }

--- a/RaspberryPiDotNet/GPIOPins.cs
+++ b/RaspberryPiDotNet/GPIOPins.cs
@@ -1,0 +1,71 @@
+﻿namespace RaspberryPiDotNet
+{
+    /// <remarks>
+    /// Refer to http://elinux.org/Rpi_Low-level_peripherals for diagram.
+    /// P1-01 = bottom left, P1-02 = top left
+    /// pi connector P1 pin    = GPIOnum
+    ///                  P1-03 = GPIO0
+    ///                  P1-05 = GPIO1
+    ///                  P1-07 = GPIO4
+    ///                  P1-08 = GPIO14 - alt function (UART0_TXD) on boot-up
+    ///                  P1-10 = GPIO15 - alt function (UART0_TXD) on boot-up
+    ///                  P1-11 = GPIO17
+    ///                  P1-12 = GPIO18
+    ///                  P1-13 = GPIO21
+    ///                  P1-15 = GPIO22
+    ///                  P1-16 = GPIO23
+    ///                  P1-18 = GPIO24
+    ///                  P1-19 = GPIO10
+    ///                  P1-21 = GPIO9
+    ///                  P1-22 = GPIO25
+    ///                  P1-23 = GPIO11
+    ///                  P1-24 = GPIO8
+    ///                  P1-26 = GPIO7
+    /// So to turn on Pin7 on the GPIO connector, pass in enumGPIOPIN.gpio4 as the pin parameter
+    /// </remarks>
+	public enum GPIOPins : uint
+	{
+		GPIO_NONE = uint.MaxValue,
+		GPIO00 = 0,
+		GPIO02_REV2 = 2,
+		GPIO03_REV2 = 3,
+		GPIO01 = 1,
+		GPIO04 = 4,
+		GPIO07 = 7,
+		GPIO08 = 8,
+		GPIO09 = 9,
+		GPIO10 = 10,
+		GPIO11 = 11,
+		GPIO14 = 14,
+		GPIO15 = 15,
+		GPIO17 = 17,
+		GPIO18 = 18,
+		GPIO21 = 21,
+		GPIO22 = 22,
+		GPIO23 = 23,
+		GPIO24 = 24,
+		GPIO25 = 25,
+		GPIO27_REV2 = 27,
+		Pin03 = 0,
+		Pin03_REV2 = 2,
+		Pin05 = 1,
+		Pin05_REV2 = 3,
+		Pin07 = 4,
+		Pin08 = 14,
+		Pin10 = 15,
+		Pin11 = 17,
+		Pin12 = 18,
+		Pin13 = 21,
+		Pin13_REV2 = 27,
+		Pin15 = 22,
+		Pin16 = 23,
+		Pin18 = 24,
+		Pin19 = 10,
+		Pin21 = 9,
+		Pin22 = 25,
+		Pin23 = 11,
+		Pin24 = 8,
+		Pin26 = 7,
+		LED = 16,
+	};
+}

--- a/RaspberryPiDotNet/MCP3008.cs
+++ b/RaspberryPiDotNet/MCP3008.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 // Original author: Mikey Sklar - git://gist.github.com/3249416.git
 // Adafruit article: http://learn.adafruit.com/reading-a-analog-in-and-controlling-audio-volume-with-the-raspberry-pi

--- a/RaspberryPiDotNet/MicroLiquidCrystal/ILcdTransferProvider.cs
+++ b/RaspberryPiDotNet/MicroLiquidCrystal/ILcdTransferProvider.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-// Micro Liquid Crystal Library
+﻿// Micro Liquid Crystal Library
 // http://microliquidcrystal.codeplex.com
 // Appache License Version 2.0
 

--- a/RaspberryPiDotNet/MicroLiquidCrystal/Lcd.cs
+++ b/RaspberryPiDotNet/MicroLiquidCrystal/Lcd.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading;
 

--- a/RaspberryPiDotNet/MicroLiquidCrystal/RaspPiGPIOFileLcdTransferProvider.cs
+++ b/RaspberryPiDotNet/MicroLiquidCrystal/RaspPiGPIOFileLcdTransferProvider.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 // Code modified from original - GPIOLcdTransferProvider.cs
 // Original code uses license:
@@ -22,19 +19,19 @@ namespace RaspberryPiDotNet.MicroLiquidCrystal
         private readonly bool _fourBitMode;
         private bool _disposed;
 
-        public RaspPiGPIOFileLcdTransferProvider(GPIOFile.GPIOPins rs, GPIOFile.GPIOPins enable, GPIOFile.GPIOPins d4, GPIOFile.GPIOPins d5, GPIOFile.GPIOPins d6, GPIOFile.GPIOPins d7)
-            : this(true, rs, GPIOFile.GPIOPins.GPIO_NONE, enable, GPIOFile.GPIOPins.GPIO_NONE, GPIOFile.GPIOPins.GPIO_NONE, GPIOFile.GPIOPins.GPIO_NONE, GPIOFile.GPIOPins.GPIO_NONE, d4, d5, d6, d7)
+        public RaspPiGPIOFileLcdTransferProvider(GPIOPins rs, GPIOPins enable, GPIOPins d4, GPIOPins d5, GPIOPins d6, GPIOPins d7)
+            : this(true, rs, GPIOPins.GPIO_NONE, enable, GPIOPins.GPIO_NONE, GPIOPins.GPIO_NONE, GPIOPins.GPIO_NONE, GPIOPins.GPIO_NONE, d4, d5, d6, d7)
         { }
 
-        public RaspPiGPIOFileLcdTransferProvider(GPIOFile.GPIOPins rs, GPIOFile.GPIOPins rw, GPIOFile.GPIOPins enable, GPIOFile.GPIOPins d4, GPIOFile.GPIOPins d5, GPIOFile.GPIOPins d6, GPIOFile.GPIOPins d7)
-            : this(true, rs, rw, enable, GPIOFile.GPIOPins.GPIO_NONE, GPIOFile.GPIOPins.GPIO_NONE, GPIOFile.GPIOPins.GPIO_NONE, GPIOFile.GPIOPins.GPIO_NONE, d4, d5, d6, d7)
+        public RaspPiGPIOFileLcdTransferProvider(GPIOPins rs, GPIOPins rw, GPIOPins enable, GPIOPins d4, GPIOPins d5, GPIOPins d6, GPIOPins d7)
+            : this(true, rs, rw, enable, GPIOPins.GPIO_NONE, GPIOPins.GPIO_NONE, GPIOPins.GPIO_NONE, GPIOPins.GPIO_NONE, d4, d5, d6, d7)
         { }
 
-        public RaspPiGPIOFileLcdTransferProvider(GPIOFile.GPIOPins rs, GPIOFile.GPIOPins enable, GPIOFile.GPIOPins d0, GPIOFile.GPIOPins d1, GPIOFile.GPIOPins d2, GPIOFile.GPIOPins d3, GPIOFile.GPIOPins d4, GPIOFile.GPIOPins d5, GPIOFile.GPIOPins d6, GPIOFile.GPIOPins d7)
-            : this(false, rs, GPIOFile.GPIOPins.GPIO_NONE, enable, d0, d1, d2, d3, d4, d5, d6, d7)
+        public RaspPiGPIOFileLcdTransferProvider(GPIOPins rs, GPIOPins enable, GPIOPins d0, GPIOPins d1, GPIOPins d2, GPIOPins d3, GPIOPins d4, GPIOPins d5, GPIOPins d6, GPIOPins d7)
+            : this(false, rs, GPIOPins.GPIO_NONE, enable, d0, d1, d2, d3, d4, d5, d6, d7)
         { }
 
-        public RaspPiGPIOFileLcdTransferProvider(GPIOFile.GPIOPins rs, GPIOFile.GPIOPins rw, GPIOFile.GPIOPins enable, GPIOFile.GPIOPins d0, GPIOFile.GPIOPins d1, GPIOFile.GPIOPins d2, GPIOFile.GPIOPins d3, GPIOFile.GPIOPins d4, GPIOFile.GPIOPins d5, GPIOFile.GPIOPins d6, GPIOFile.GPIOPins d7)
+        public RaspPiGPIOFileLcdTransferProvider(GPIOPins rs, GPIOPins rw, GPIOPins enable, GPIOPins d0, GPIOPins d1, GPIOPins d2, GPIOPins d3, GPIOPins d4, GPIOPins d5, GPIOPins d6, GPIOPins d7)
             : this(false, rs, rw, enable, d0, d1, d2, d3, d4, d5, d6, d7)
         { }
 
@@ -53,27 +50,27 @@ namespace RaspberryPiDotNet.MicroLiquidCrystal
         /// <param name="d5"></param>
         /// <param name="d6"></param>
         /// <param name="d7"></param>
-        public RaspPiGPIOFileLcdTransferProvider(bool fourBitMode, GPIOFile.GPIOPins rs, GPIOFile.GPIOPins rw, GPIOFile.GPIOPins enable, 
-                                                 GPIOFile.GPIOPins d0, GPIOFile.GPIOPins d1, GPIOFile.GPIOPins d2, GPIOFile.GPIOPins d3, 
-                                                 GPIOFile.GPIOPins d4, GPIOFile.GPIOPins d5, GPIOFile.GPIOPins d6, GPIOFile.GPIOPins d7)
+        public RaspPiGPIOFileLcdTransferProvider(bool fourBitMode, GPIOPins rs, GPIOPins rw, GPIOPins enable, 
+                                                 GPIOPins d0, GPIOPins d1, GPIOPins d2, GPIOPins d3, 
+                                                 GPIOPins d4, GPIOPins d5, GPIOPins d6, GPIOPins d7)
         {
             _fourBitMode = fourBitMode;
 
-            if (rs == GPIOFile.GPIOPins.GPIO_NONE) throw new ArgumentException("rs");
+            if (rs == GPIOPins.GPIO_NONE) throw new ArgumentException("rs");
             _rsPort = new GPIOFile(rs);
 
             // we can save 1 pin by not using RW. Indicate by passing GPIO.GPIOPins.GPIO_NONE instead of pin#
-            if (rw != GPIOFile.GPIOPins.GPIO_NONE) // (RW is optional)
+            if (rw != GPIOPins.GPIO_NONE) // (RW is optional)
                 _rwPort = new GPIOFile(rw);
 
-            if (enable == GPIOFile.GPIOPins.GPIO_NONE) throw new ArgumentException("enable");
+            if (enable == GPIOPins.GPIO_NONE) throw new ArgumentException("enable");
             _enablePort = new GPIOFile(enable);
 
             var dataPins = new[] { d0, d1, d2, d3, d4, d5, d6, d7};
             _dataPorts = new GPIOFile[8];
             for (int i = 0; i < 8; i++)
             {
-                if (dataPins[i] != GPIOFile.GPIOPins.GPIO_NONE)
+                if (dataPins[i] != GPIOPins.GPIO_NONE)
                     _dataPorts[i] = new GPIOFile(dataPins[i]);
             }
         }

--- a/RaspberryPiDotNet/MicroLiquidCrystal/RaspPiGPIOMemLcdTransferProvider.cs
+++ b/RaspberryPiDotNet/MicroLiquidCrystal/RaspPiGPIOMemLcdTransferProvider.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 // Code modified from original - GPIOLcdTransferProvider.cs
 // Original code uses license:
@@ -22,19 +19,19 @@ namespace RaspberryPiDotNet.MicroLiquidCrystal
         private readonly bool _fourBitMode;
         private bool _disposed;
 
-        public RaspPiGPIOMemLcdTransferProvider(GPIOMem.GPIOPins rs, GPIOMem.GPIOPins enable, GPIOMem.GPIOPins d4, GPIOMem.GPIOPins d5, GPIOMem.GPIOPins d6, GPIOMem.GPIOPins d7)
-            : this(true, rs, GPIOMem.GPIOPins.GPIO_NONE, enable, GPIOMem.GPIOPins.GPIO_NONE, GPIOMem.GPIOPins.GPIO_NONE, GPIOMem.GPIOPins.GPIO_NONE, GPIOMem.GPIOPins.GPIO_NONE, d4, d5, d6, d7)
+        public RaspPiGPIOMemLcdTransferProvider(GPIOPins rs, GPIOPins enable, GPIOPins d4, GPIOPins d5, GPIOPins d6, GPIOPins d7)
+            : this(true, rs, GPIOPins.GPIO_NONE, enable, GPIOPins.GPIO_NONE, GPIOPins.GPIO_NONE, GPIOPins.GPIO_NONE, GPIOPins.GPIO_NONE, d4, d5, d6, d7)
         { }
 
-        public RaspPiGPIOMemLcdTransferProvider(GPIOMem.GPIOPins rs, GPIOMem.GPIOPins rw, GPIOMem.GPIOPins enable, GPIOMem.GPIOPins d4, GPIOMem.GPIOPins d5, GPIOMem.GPIOPins d6, GPIOMem.GPIOPins d7)
-            : this(true, rs, rw, enable, GPIOMem.GPIOPins.GPIO_NONE, GPIOMem.GPIOPins.GPIO_NONE, GPIOMem.GPIOPins.GPIO_NONE, GPIOMem.GPIOPins.GPIO_NONE, d4, d5, d6, d7)
+        public RaspPiGPIOMemLcdTransferProvider(GPIOPins rs, GPIOPins rw, GPIOPins enable, GPIOPins d4, GPIOPins d5, GPIOPins d6, GPIOPins d7)
+            : this(true, rs, rw, enable, GPIOPins.GPIO_NONE, GPIOPins.GPIO_NONE, GPIOPins.GPIO_NONE, GPIOPins.GPIO_NONE, d4, d5, d6, d7)
         { }
 
-        public RaspPiGPIOMemLcdTransferProvider(GPIOMem.GPIOPins rs, GPIOMem.GPIOPins enable, GPIOMem.GPIOPins d0, GPIOMem.GPIOPins d1, GPIOMem.GPIOPins d2, GPIOMem.GPIOPins d3, GPIOMem.GPIOPins d4, GPIOMem.GPIOPins d5, GPIOMem.GPIOPins d6, GPIOMem.GPIOPins d7)
-            : this(false, rs, GPIOMem.GPIOPins.GPIO_NONE, enable, d0, d1, d2, d3, d4, d5, d6, d7)
+        public RaspPiGPIOMemLcdTransferProvider(GPIOPins rs, GPIOPins enable, GPIOPins d0, GPIOPins d1, GPIOPins d2, GPIOPins d3, GPIOPins d4, GPIOPins d5, GPIOPins d6, GPIOPins d7)
+            : this(false, rs, GPIOPins.GPIO_NONE, enable, d0, d1, d2, d3, d4, d5, d6, d7)
         { }
 
-        public RaspPiGPIOMemLcdTransferProvider(GPIOMem.GPIOPins rs, GPIOMem.GPIOPins rw, GPIOMem.GPIOPins enable, GPIOMem.GPIOPins d0, GPIOMem.GPIOPins d1, GPIOMem.GPIOPins d2, GPIOMem.GPIOPins d3, GPIOMem.GPIOPins d4, GPIOMem.GPIOPins d5, GPIOMem.GPIOPins d6, GPIOMem.GPIOPins d7)
+        public RaspPiGPIOMemLcdTransferProvider(GPIOPins rs, GPIOPins rw, GPIOPins enable, GPIOPins d0, GPIOPins d1, GPIOPins d2, GPIOPins d3, GPIOPins d4, GPIOPins d5, GPIOPins d6, GPIOPins d7)
             : this(false, rs, rw, enable, d0, d1, d2, d3, d4, d5, d6, d7)
         { }
 
@@ -53,27 +50,27 @@ namespace RaspberryPiDotNet.MicroLiquidCrystal
         /// <param name="d5"></param>
         /// <param name="d6"></param>
         /// <param name="d7"></param>
-        public RaspPiGPIOMemLcdTransferProvider(bool fourBitMode, GPIOMem.GPIOPins rs, GPIOMem.GPIOPins rw, GPIOMem.GPIOPins enable, 
-                                                 GPIOMem.GPIOPins d0, GPIOMem.GPIOPins d1, GPIOMem.GPIOPins d2, GPIOMem.GPIOPins d3, 
-                                                 GPIOMem.GPIOPins d4, GPIOMem.GPIOPins d5, GPIOMem.GPIOPins d6, GPIOMem.GPIOPins d7)
+        public RaspPiGPIOMemLcdTransferProvider(bool fourBitMode, GPIOPins rs, GPIOPins rw, GPIOPins enable, 
+                                                 GPIOPins d0, GPIOPins d1, GPIOPins d2, GPIOPins d3, 
+                                                 GPIOPins d4, GPIOPins d5, GPIOPins d6, GPIOPins d7)
         {
             _fourBitMode = fourBitMode;
 
-            if (rs == GPIOMem.GPIOPins.GPIO_NONE) throw new ArgumentException("rs");
+            if (rs == GPIOPins.GPIO_NONE) throw new ArgumentException("rs");
             _rsPort = new GPIOMem(rs);
 
             // we can save 1 pin by not using RW. Indicate by passing GPIO.GPIOPins.GPIO_NONE instead of pin#
-            if (rw != GPIOMem.GPIOPins.GPIO_NONE) // (RW is optional)
+            if (rw != GPIOPins.GPIO_NONE) // (RW is optional)
                 _rwPort = new GPIOMem(rw);
 
-            if (enable == GPIOMem.GPIOPins.GPIO_NONE) throw new ArgumentException("enable");
+            if (enable == GPIOPins.GPIO_NONE) throw new ArgumentException("enable");
             _enablePort = new GPIOMem(enable);
 
             var dataPins = new[] { d0, d1, d2, d3, d4, d5, d6, d7};
             _dataPorts = new GPIOMem[8];
             for (int i = 0; i < 8; i++)
             {
-                if (dataPins[i] != GPIOMem.GPIOPins.GPIO_NONE)
+                if (dataPins[i] != GPIOPins.GPIO_NONE)
                     _dataPorts[i] = new GPIOMem(dataPins[i]);
             }
         }

--- a/RaspberryPiDotNet/RaspberryPiDotNet.csproj
+++ b/RaspberryPiDotNet/RaspberryPiDotNet.csproj
@@ -10,8 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RaspberryPiDotNet</RootNamespace>
     <AssemblyName>RaspberryPiDotNet</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,19 +35,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DS1620.cs" />
     <Compile Include="GPIO.cs" />
     <Compile Include="GPIODebug.cs" />
+    <Compile Include="GPIODirection.cs" />
     <Compile Include="GPIOFile.cs" />
     <Compile Include="GPIOMem.cs" />
+    <Compile Include="GPIOPins.cs" />
     <Compile Include="MCP3008.cs" />
     <Compile Include="MicroLiquidCrystal\RaspPiGPIOFileLcdTransferProvider.cs" />
     <Compile Include="MicroLiquidCrystal\RaspPiGPIOMemLcdTransferProvider.cs" />

--- a/RaspberryPiDotNet/TM16XX/TM1638.cs
+++ b/RaspberryPiDotNet/TM16XX/TM1638.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 // This class is the base class for the TM1638/TM1640 board.
 // It is a port of the TM1638 library by Ricardo Batista

--- a/RaspberryPiDotNet/TM16XX/TM16XX.cs
+++ b/RaspberryPiDotNet/TM16XX/TM16XX.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 // This class is the base class for the TM1638/TM1640 board.
 // It is a port of the TM1638 library by Ricardo Batista
@@ -173,7 +171,7 @@ namespace RaspberryPiDotNet
         public void setDisplayDigit(byte digit, byte pos, bool dot)
         {
             char chr = Char.Parse(digit.ToString());
-            if (charMap.Keys.Contains(chr))
+            if (charMap.ContainsKey(chr))
                 sendChar(pos, charMap[digit.ToString()[0]], dot);
         }
 


### PR DESCRIPTION
Hi,

I was looking for a C# Pi GPIO implementation and came across this project, I needed far better performance on the GPIOMem and saw some room for improvements. So (for the first time ever in my life) I saw an opportunity to contribute back to a project (hope I did the Git part ok, have never used it before).

I managed about a 146x speedup on writes and 250.9x on reads. The GPIOFile has also improved from restructuring some OO and c# language aspects of the project, but since I didn't need it I decided to not optimize it. (You can keep the relevant files open instead of using File.ReadAllText and WriteAllText, they are FUBAR slow. But this would slightly change the semantics of what is happening and eliminate sharing of the GPIO pins among multiple processes at the same time) Most ppl needing performance will look for the Mem variant anyway.

Here is a short list of how/why I changed stuff if you want to know:
- Moved to .Net 2.0, no reason to use 4.0. Eliminates a bunch of dependencies.
- Corrected usings (no .Linq in 2.0)
- Corrected .ctor overloading and overriding. GPIO... ctor(x) now goes to GPIO... ctor(x,y,z), and then GPIO.ctor(x,y,z). Such that the super class may perform init in the 3 parameter .ctor regardless of what ctor was initially called, this unduplicates code. The GPIO base class 1 and 2 parameter .ctors are thus redundant and removed.
- Modeled everything to use GPIO instances, and not static methods. Much more OO-ish and much less C-ish. The static methods are now based on the instances vs. the other way around. (This touches upon personal style, this can be changed around if needed, but using instances is more natural imo)
- Corected use of the IDisposed interface (no need to repeat this on sub classes btw, but admittedly doesn't do harm either). Member access now throws an exception after the GPIO instance is disposed.
- Defining the GPIOPins enum as derived from uint allows it to be directly used in the dll imports, saves on the cast calls in code (doesn't make much run time difference though)
- Using bool directly in dllimport is no problem, at run time (any sane platform) will use native int for them. Eliminates a bunch of == 0? .. : .. expressions.
- Added factory method (CreatePin) that creates GPIOMem if possible and GPIOFile as fallback. This allows the static read and write methods to go to GPIO, and not have a static GPIOMem.Write() and separate static GPIOFile.Write()
- In debug builds, factory method falls back to GPIODebug if GPIOFile also fails
- Corrected DirectionEnum to read GPIODirection. To include Enum in the name of an enum is bad style imo, it serves no purpose (or atleast is not consistent with naming the other enum GPIOPins, that should then be PinsEnum).
- I also saw no reason GPIODirection and GPIOPins should be nested in GPIO (GPIO.GPIO... adds no readability, and makes you type and extra GPIO. every time), but this als is a bit of sylistic difference.
- Static are useless in GPIODebug, there are no overrides (in c#) for static methods, so a base class can never call these, and manually calling GPIODebug.CleanUp() serves little purpose.
- Finalizer behaviour can be generalized to GPIO class, makes sense since it is also the class declaring the IDisposabe.
- Static class initializer is better than using static _initialized variable. The runtime ensures thread safety and guarantees it runs exactly only once before using the class. Perfect place for bcm2835_init().
- Corrected dictionary accesses to read .ContainsKey() instead of .Keys.Contains(). This last form is the only v4.0 framwork feature used in the project. This statement acutally causes a new object to be created in the .Keys getter, and an extension method to run on that object. The dictionary provide a convenient (and v2.0 compatible) .ContainsKey() method.
- Added xml comments on all public items needing them in GPIO{,Mem,File} classes

Using a simple app that just repeats writes/read I got the following timings on the Pi.
Timings:
Original:
Mem IO:
Time for 200k writes: 21764.569ms
Time for 200k reads: 19576.452ms

File IO:
Time for 200k writes: 330967.659ms
Time for 200k reads: 366102.993ms

Modified:
Mem IO:
Time for 200k writes: 149.032ms
Time for 200k reads: 78.91ms

File IO:
Time for 200k writes: 285773.429ms
Time for 200k reads: 306495.585ms
